### PR TITLE
feat: Add unmountOnBlur option to New Tabs.Screen

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -115,6 +115,7 @@ export default function createRouter(isSigned = false) {
         name="New"
         component={NewStack}
         options={{
+          unmountOnBlur: true,
           tabBarVisible: false,
           tabBarLabel: 'Agendar',
           tabBarIcon: ({ color }) => (


### PR DESCRIPTION
With the option added, the Tabs.Screen named "New" will be dismounted after the user navigates away from it. This way, after an appointment is confirmed, the user will not return to the confirmation screen after clicking on the "Agendar" tab.